### PR TITLE
Update tox.ini file envlist with python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
         - python3.4
         - python3.5
         - python3.6
+        - python3.7
         - libgmp10
         - upx-ucl
         - shellcheck

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,12 @@ To be released.
  -  Fixed an incorrect processing of [CommonMark] thight list items: it had
     crashed when a thight list item contains blocks other than paragraphs.
 
+### Python target
+
+ -  Python 3.7 support. [[#298]]
+
+[#298]: https://github.com/nirum-lang/nirum/issues/298
+
 ### Et cetera
 
  -  Dropped 32-bit Windows support.

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist =
     py34
     py35
     py36
+    py37
 skipsdist = true
 
 [testenv]


### PR DESCRIPTION
Closes #298 

### Brief Summary
Add python3.7 support.
Add `.travis.yml` python3.7 option cause the [deadsnakes PPA](https://github.com/deadsnakes/python3.7) supports 3.7

### TODOs:
OSX's [homebrew-deadsnakes](https://github.com/drolando/homebrew-deadsnakes) doesn't support python3.6 and 3.7 currently (Aug 15 2018)
If you need to build it with the versions above, then please add formulas and add details on `.travis.yml`