### PR TITLE
Escape code blocks

### DIFF
--- a/src/Nirum/Docs/Html.hs
+++ b/src/Nirum/Docs/Html.hs
@@ -64,8 +64,11 @@ renderBlock (BlockQuote blocks) =
 renderBlock (HtmlBlock html) = html
 renderBlock (CodeBlock lang code') =
     if T.null lang
-    then [qq|<pre><code>$code'</code></pre>|]
-    else [qq|<pre><code class="language-$lang">$code'</code></pre>|]
+    then [qq|<pre><code>$escapedCode</code></pre>|]
+    else [qq|<pre><code class="language-$lang">$escapedCode</code></pre>|]
+  where
+    escapedCode :: Html
+    escapedCode = escape code'
 renderBlock (Heading level inlines anchorId) =
     let lv = headingLevelInt level
         id' = case anchorId of


### PR DESCRIPTION
When compiler generate `CodeBlock`, it doesn't escape its code. So if code contain HTML special characters, compiled into HTML tag. 

I escaped `code'` so that `code'` is not rendered to HTML elements.

Closes #301