### PR TITLE
Added `opengraphs` option for open graph tags on docs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ To be released.
     crashed when a thight list item contains blocks other than paragraphs.
  -  Package's version became shown on the generated docs.
     [[#297], [#304] by Jeong Ukjae]
+ -  Added `opengraphs` option for [OpenGraph] objects on docs. [[#283] by GyuYong Jung]
 
 ### Python target
 
@@ -42,12 +43,14 @@ To be released.
 
 [#126]: https://github.com/nirum-lang/nirum/issues/126
 [#281]: https://github.com/nirum-lang/nirum/pull/281
+[#283]: https://github.com/spoqa/nirum/pull/283
 [#297]: https://github.com/nirum-lang/nirum/issues/297
 [#300]: https://github.com/nirum-lang/nirum/pull/300
 [#304]: https://github.com/nirum-lang/nirum/pull/304
 [CommonMark]: http://commonmark.org/
 [table syntax extension]: https://github.github.com/gfm/#tables-extension-
 [special attributes extension]: https://michelf.ca/projects/php-markdown/extra/#spe-attr
+[OpenGraph]: http://ogp.me/
 
 
 Version 0.4.1

--- a/app/nirum-docs.hs
+++ b/app/nirum-docs.hs
@@ -31,6 +31,7 @@ packageMetadata = Metadata
     , authors = [Author "Nirum team" Nothing Nothing]
     , Nirum.Package.Metadata.target = Docs
         { docsTitle = "Nirum"
+        , docsOpenGraph = []
         , docsStyle = style
         , docsHeader = ""
         , docsFooter = footer

--- a/docs/target/docs.md
+++ b/docs/target/docs.md
@@ -45,6 +45,11 @@ Settings
 It goes to `<title>` elements of generated HTML pages.  It's usually a name of
 the Nirum package.
 
+### `opengraphs` (optional): OpenGraph
+
+It goes to `<meta>` elements of generated HTML pages. It generate OpenGraph
+objects.
+
 
 ### `style` (optional): Custom CSS
 

--- a/src/Nirum/Package/Metadata.hs
+++ b/src/Nirum/Package/Metadata.hs
@@ -48,6 +48,7 @@ module Nirum.Package.Metadata ( Author (Author, email, name, uri)
                               , readMetadata
                               , stringField
                               , tableField
+                              , tableArrayField
                               , textArrayField
                               , versionField
                               ) where


### PR DESCRIPTION
Usage:

```toml
[targets.docs]
title = "Nirum Examples"

  [[targets.docs.opengraphs]]
  tag = "og:url"
  content = "https://nirum.org"

  [[targets.docs.opengraphs]]
  tag = "og:title"
  content = "Nirum Examples"
```

Closes: #283