### PR TITLE
Fixed typo on some docs

### DIFF
--- a/docs/package.md
+++ b/docs/package.md
@@ -1,7 +1,7 @@
 Package
 =======
 
-Unlike many other RPC framworks/IDL compilers, Nirum's single unit of
+Unlike many other RPC frameworks/IDL compilers, Nirum's single unit of
 compilation is not a source file, but a package of source files.
 Each package is compiled to a package of target language (e.g. Python package
 with setup.py file).  The following example is an ordinary Nirum package:

--- a/docs/refactoring.md
+++ b/docs/refactoring.md
@@ -240,9 +240,9 @@ to change it to a union:
 
 ~~~~~~~~ nirum
 union name
-    = wastern-name (text first-name, text? middle-name, text last-name)
+    = western-name (text first-name, text? middle-name, text last-name)
     | east-asian-name (text family-name, text given-name)
-    | culture-agnostice-name (text fullname)
+    | culture-agnostic-name (text fullname)
     ;
 ~~~~~~~~
 
@@ -256,9 +256,9 @@ In order to make union types possible to deserialize existing record data
 
 ~~~~~~~~ nirum
 union name
-    = wastern-name (text first-name, text? middle-name, text last-name)
+    = western-name (text first-name, text? middle-name, text last-name)
     | east-asian-name (text family-name, text given-name)
-    | default culture-agnostice-name (text fullname)
+    | default culture-agnostic-name (text fullname)
     ;
 ~~~~~~~~
 

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -53,7 +53,7 @@ representation.  Although we recommend to use hyphens to separate words
 when declare names in Nirum code, these hyphens must be replaced by underscores
 in JSON. The following are normalization rules:
 
- -  Use lowercase alphabets instead of uppercases.
+ -  Use lowercase alphabets instead of uppercase.
  -  Use underscores instead of hyphens.
     This rule may help to implement a runtime library for programming languages
     disallowing hyphens for identifiers.
@@ -247,7 +247,7 @@ It's represented in JSON to:
         "url": null
     }
 
-In a similar way to a recrod type, undefined fields in a payload are ignored
+In a similar way to a record type, undefined fields in a payload are ignored
 by deserializer.
 
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -734,7 +734,7 @@ Method parameters
 The previous example was designed to minimize the complexity by intention.
 That's why `increment()` method has no parameters.
 
-In this chapter, the `counter` example slighly evolves.  Previously,
+In this chapter, the `counter` example slightly evolves.  Previously,
 `increment()` method only can increment the state by 1.  How about making
 it possible to increment the state by any delta?  If the previous one is
 like a microservice version of `++state` this one is like a microservice


### PR DESCRIPTION
### Brief Summary
Fixed typo on 
+ docs/package.md
+ docs/refactoring.md
+ docs/serialization.md
+ docs/tutorial.md