### PR TITLE
Trim -Werror option before uploading to Hackage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -217,7 +217,7 @@ after_deploy: |
   popd
 
   # sdist
-  sed -i 's/^- -Werror$//g' package.yaml   # Hackage disallows -Werror
+  sed -i -E 's/\s-Werror$/ -Wwarn/g' package.yaml   # Hackage disallows -Werror
   stack --no-terminal sdist --ignore-check
 
   # Upload sdist as well to GitHub Releases

--- a/package.yaml
+++ b/package.yaml
@@ -19,7 +19,7 @@ category: Language
 author: Nirum team
 maintainer: Nirum team
 copyright: (c) 2016–2018 Nirum team
-license: GPL-3
+license: GPL-3.0-or-later
 homepage: https://nirum.org/
 git: git://github.com/nirum-lang/nirum.git
 bug-reports: https://github.com/nirum-lang/nirum/issues


### PR DESCRIPTION
This fixes the build error #325.  Although there has been a `sed` script intending the same trick, it actually hadn't worked.  I changed it to replace [`-Werror`][1] with [`-Wwarn`][2] rather than remove it, because it can lead to an invalid YAML.  For example, given the following YAML:

```yaml
ghc-options:
- -Werror
other-options: ...
```

if the item `- -Werror` is removed it becomes invalid:

```yaml
ghc-options:  # YAML syntax disallows this
other-options: ...
```

Also, although we license the Nirum compiler under “GPL 3.0 or higher” not “GPL 3.0 only,” as `GPL-3` means the latter, I changed it to [`GPL-3.0-or-later`][3].  (Note that [since Cabal 2.2 `license` field supports SPDX syntax.][4])

[1]: https://downloads.haskell.org/~ghc/8.4.3/docs/html/users_guide/using-warnings.html#ghc-flag--Werror
[2]: https://downloads.haskell.org/~ghc/8.4.3/docs/html/users_guide/using-warnings.html#ghc-flag--Wwarn
[3]: https://spdx.org/licenses/GPL-3.0-or-later.html
[4]: https://github.com/haskell/cabal/pull/4732#issuecomment-326567777