### PR TITLE
Add annotation metadata on generated union type classes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ To be released.
 ### Python target
 
  -  Added `__nirum_annotations__` static field on generated union type classes.
-    [[#273] by jangjunha]
+    [[#273] by Jang Junha]
 
 [#273]: https://github.com/nirum-lang/nirum/issues/273
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ Version 0.6.0
 
 To be released.
 
+### Python target
+
+ -  Added `__nirum_annotations__` static field on generated union type classes.
+    [[#273] by jangjunha]
+
+[#273]: https://github.com/nirum-lang/nirum/issues/273
+
 
 Version 0.5.0
 -------------

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -402,9 +402,6 @@ toMethodParameterCode source vInput vOutput vError
         , mpcDeserializer = deserializer
         }
 
-escapeSingle :: T.Text -> T.Text
-escapeSingle = T.strip . T.replace "'" "\\'"
-
 defaultDeserializerErrorHandler :: CodeGen Code
 defaultDeserializerErrorHandler = do
     modify $ \ c@CodeGenContext { globalDefinitions = defs } ->
@@ -1079,7 +1076,7 @@ class #{className}(#{T.intercalate "," $ compileExtendClasses annotations}):
             '#{toAttributeName annoArgIdent}':
 %{ case annoArg }
 %{ of AI.Text t }
-                u'''#{escapeSingle t}''',
+                #{stringLiteral t},
 %{ of AI.Integer i }
                 #{i},
 %{ endcase }
@@ -1497,7 +1494,7 @@ if hasattr(#{className}.Client, '__qualname__'):
                 ]
       where
         annoArgToText :: AnnotationArgument -> T.Text
-        annoArgToText (AI.Text t) = [qq|u'''{escapeSingle t}'''|]
+        annoArgToText (AI.Text t) = stringLiteral t
         annoArgToText (Integer i) = T.pack $ show i
     compileMethodAnnotation :: Method -> T.Text
     compileMethodAnnotation Method { methodName = mName

--- a/test/nirum_fixture/fixture/foo.nrm
+++ b/test/nirum_fixture/fixture/foo.nrm
@@ -144,3 +144,10 @@ record name-shadowing-field-record (
 union optional-union = foo ( int32? bar )
                      | baz ( int32 qux )
                      ;
+
+@annot(number-arg=2, text-arg="Nirum '니름'")
+union union-with-annotation
+    # Docs annotation.
+    = union-tag-a ( int32 aaa )
+    | union-tag-b ( int32 bbb )
+    ;

--- a/test/python/annotation_test.py
+++ b/test/python/annotation_test.py
@@ -1,5 +1,5 @@
 from fixture.datetime import DatetimeService
-from fixture.foo import PingService, RpcError
+from fixture.foo import PingService, RpcError, UnionWithAnnotation
 from nirum.datastructures import Map
 
 
@@ -21,3 +21,14 @@ def test_annotation_int():
         'num_constraints': Map({'max': 12, 'min': 1}),
     })
     assert DatetimeService.__nirum_method_annotations__['delta_month'] == exp
+
+
+def test_annotation_union():
+    exp = Map({
+        'annot': Map({
+            'number_arg': 2,
+            'text_arg': u'Nirum \'\ub2c8\ub984\'',
+        }),
+        'docs': Map({'docs': u'Docs annotation.'}),
+    })
+    assert UnionWithAnnotation.__nirum_annotations__ == exp

--- a/test/python/annotation_test.py
+++ b/test/python/annotation_test.py
@@ -9,7 +9,7 @@ def test_annotation_as_error():
 
 def test_service_method_annotation_metadata():
     expect = Map({
-        'docs': Map({'docs': u'Method docs.'}),
+        'docs': Map({'docs': u'Method docs.\n'}),
         'http_resource': Map({'method': u'GET', 'path': u'/ping'}),
         'quote': Map({'single': u"'", 'triple': u"'''"}),
         'unicode': Map({'unicode': u'\uc720\ub2c8\ucf54\ub4dc'}), })
@@ -29,6 +29,6 @@ def test_annotation_union():
             'number_arg': 2,
             'text_arg': u'Nirum \'\ub2c8\ub984\'',
         }),
-        'docs': Map({'docs': u'Docs annotation.'}),
+        'docs': Map({'docs': u'Docs annotation.\n'}),
     })
     assert UnionWithAnnotation.__nirum_annotations__ == exp


### PR DESCRIPTION
Added `__nirum_annotations__` static field on generated **union** type python classes.

Issue #273 